### PR TITLE
Modernize project: add Claude AI recommendations, tests, and proper structure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in your API key
+# Get your key at https://console.anthropic.com/
+ANTHROPIC_API_KEY=your_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.env
+.bundle/
+vendor/
+.rspec_status
+coverage/

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format documentation
+--color

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+ruby ">= 3.0"
+
+gem "anthropic"       # Claude AI API client
+gem "base64"          # Required by anthropic gem (Ruby 3.4+ compatibility)
+gem "colorize"        # Terminal text colorization
+gem "dotenv"          # Environment variable management
+
+group :development, :test do
+  gem "rspec"         # Testing framework
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,42 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    anthropic (1.24.0)
+      cgi
+      connection_pool
+    base64 (0.3.0)
+    cgi (0.5.1)
+    colorize (1.1.0)
+    connection_pool (3.0.2)
+    diff-lcs (1.6.2)
+    dotenv (3.2.0)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  anthropic
+  base64
+  colorize
+  dotenv
+  rspec
+
+RUBY VERSION
+   ruby 3.3.6p108
+
+BUNDLED WITH
+   2.5.0

--- a/spec/jukebox_spec.rb
+++ b/spec/jukebox_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe Jukebox do
+  subject(:jukebox) { described_class.new }
+
+  describe "#running?" do
+    it "is true on initialization" do
+      expect(jukebox.running?).to be true
+    end
+  end
+
+  describe "constants" do
+    it "defines 6 moods" do
+      expect(Jukebox::MOODS.length).to eq(6)
+    end
+
+    it "defines 6 occasions" do
+      expect(Jukebox::OCCASIONS.length).to eq(6)
+    end
+
+    it "moods are frozen" do
+      expect(Jukebox::MOODS).to be_frozen
+    end
+
+    it "occasions are frozen" do
+      expect(Jukebox::OCCASIONS).to be_frozen
+    end
+  end
+end

--- a/spec/music_recommender_spec.rb
+++ b/spec/music_recommender_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe MusicRecommender do
+  subject(:recommender) { described_class.new }
+
+  describe "#ai_available?" do
+    context "when ANTHROPIC_API_KEY is not set" do
+      before { allow(ENV).to receive(:[]).with("ANTHROPIC_API_KEY").and_return(nil) }
+
+      it "returns false" do
+        expect(recommender.ai_available?).to be false
+      end
+    end
+
+    context "when ANTHROPIC_API_KEY is the placeholder" do
+      before { allow(ENV).to receive(:[]).with("ANTHROPIC_API_KEY").and_return("your_api_key_here") }
+
+      it "returns false" do
+        expect(recommender.ai_available?).to be false
+      end
+    end
+  end
+
+  describe "#recommend" do
+    context "with fallback data (no API key)" do
+      before { allow(ENV).to receive(:[]).with("ANTHROPIC_API_KEY").and_return(nil) }
+
+      it "returns a song for a valid mood" do
+        song = recommender.recommend(category_type: :mood, category_name: "Rage")
+
+        expect(song).to be_a(Hash)
+        expect(song[:title]).to be_a(String)
+        expect(song[:artist]).to be_a(String)
+        expect(song[:url]).to be_a(String)
+      end
+
+      it "returns a song for a valid occasion" do
+        song = recommender.recommend(category_type: :occasion, category_name: "Dance Battle")
+
+        expect(song).to be_a(Hash)
+        expect(song[:title]).not_to be_empty
+        expect(song[:artist]).not_to be_empty
+      end
+
+      it "returns nil for an unknown category" do
+        song = recommender.recommend(category_type: :mood, category_name: "Nonexistent Mood")
+        expect(song).to be_nil
+      end
+
+      it "returns different songs on repeated calls (probabilistic)" do
+        songs = 10.times.map { recommender.recommend(category_type: :mood, category_name: "Rage") }
+        titles = songs.map { |s| s[:title] }.uniq
+        expect(titles.length).to be >= 2
+      end
+    end
+  end
+
+  describe "fallback data integrity" do
+    it "loads fallback data with moods and occasions" do
+      data_path = File.join(__dir__, "../src/data/songs.json")
+      data = JSON.parse(File.read(data_path))
+
+      expect(data["moods"]).to be_a(Hash)
+      expect(data["occasions"]).to be_a(Hash)
+      expect(data["moods"].keys).to include("Rage", "In love", "Blue")
+      expect(data["occasions"].keys).to include("Dance Battle", "Fancy Dinner Party")
+    end
+
+    it "has at least 2 songs per category" do
+      data_path = File.join(__dir__, "../src/data/songs.json")
+      data = JSON.parse(File.read(data_path))
+
+      (data["moods"].values + data["occasions"].values).each do |songs|
+        expect(songs.length).to be >= 2
+      end
+    end
+
+    it "has required fields for each song" do
+      data_path = File.join(__dir__, "../src/data/songs.json")
+      data = JSON.parse(File.read(data_path))
+
+      all_songs = data["moods"].values.flatten + data["occasions"].values.flatten
+      all_songs.each do |song|
+        expect(song).to have_key("title")
+        expect(song).to have_key("artist")
+        expect(song).to have_key("url")
+        expect(song["url"]).to start_with("https://")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "dotenv/load"
+require_relative "../src/music_recommender"
+require_relative "../src/Jukebox"

--- a/src/Jukebox.rb
+++ b/src/Jukebox.rb
@@ -1,215 +1,138 @@
+# frozen_string_literal: true
+
 require "colorize"
+require_relative "music_recommender"
 
 class Jukebox
-    attr_reader :choice1, :choice2, :jukebox_running
-    def initialize
-        @user_name = nil
+  MOODS = [
+    "On top of the world",
+    "Blue",
+    "In love",
+    "Sleep deprived",
+    "Rage",
+    "A little high"
+  ].freeze
 
-        # Becomes 1 or 2 when user chooses mood or occasion, is nil so it can become a variable
-        @choice1 = nil
+  OCCASIONS = [
+    "Netflix & Chill",
+    "Dance Battle",
+    "Fantasy Board Game Night",
+    "Cosplay Party",
+    "Fancy Dinner Party",
+    "Hangin' Out With Garret"
+  ].freeze
 
-        # Becomes 1-6 when user chooses category under mood/occasion, is nil so it can become a variable
-        @choice2 = nil
+  def initialize
+    @recommender = MusicRecommender.new
+    @user_name = nil
+    @running = true
+  end
 
-        # Do we choose another song?
-        @choice3 = nil
+  def running?
+    @running
+  end
 
-        # Initiates the jukebox loop when we open the class
-        @jukebox_running = true
+  def greeting
+    puts "\n" + "╔══════════════════════════════════════╗".colorize(:light_magenta)
+    puts       "║   Ben & Mike's Song Suggestor  v2.0  ║".colorize(:light_magenta)
+    puts       "╚══════════════════════════════════════╝".colorize(:light_magenta)
 
-        # Create an array of moods to print
-        @moods = [
-            "1. On top of the world", 
-            "2. Blue", 
-            "3. In love", 
-            "4. Sleep deprived", 
-            "5. Rage", 
-            "6. A little high"
-        ]
-
-        # Create an array of occasions to print
-        @occasions = [
-            "1. Netflix & Chill", 
-            "2. Dance Battle", 
-            "3. Fantasy Board Game Night", 
-            "4. Cosplay Party", 
-            "5. Fancy Dinner Party", 
-            "6. Hangin' Out With Garret"
-        ]
-        
-        # A long series of arrays containing the songs associated with each mood or occasion
-
-        # Moods
-        on_top = [
-            ["Happy", "Pharrell Williams", "https://www.youtube.com/watch?v=ZbZSe6N_BXs"],
-            ["Hawaiian Roller Coaster Ride", "Mark Keali'i Ho'omalu, Kamehameha Schools Children's Chorus", "https://www.youtube.com/watch?v=KaLFZj3wPsc"]
-        ]
-        blue = [
-            ["Blue (Da Ba Dee)", "Eiffel 65", "https://www.youtube.com/watch?v=68ugkg9RePc"],
-            ["Born To Die", "Lana Del Rey", "https://www.youtube.com/watch?v=ORnYNaTZGUU"]
-        ]
-        in_love = [
-            ["You Are The Sunshine Of My Life", "Stevie Wonder", "https://www.youtube.com/watch?v=3wZ_b_uUAdQ"],
-            ["Just The Way You Are", "Bruno Mars", "https://www.youtube.com/watch?v=LjhCEhWiKXk&list=PLx3wWkQvD0wuLg05pvb6lwmpnzdW52bSH"]
-        ]
-        sleep = [
-            ["A Whole New World", "John McClung", "https://www.youtube.com/watch?v=-GN997853gc"],
-            ["Pua Lilelehua", "Keola Beamer", "https://www.youtube.com/watch?v=s0WyqmvAg7o"]
-        ]
-        rage = [
-            ["Kamikaze", "Eminem", "https://www.youtube.com/watch?v=FhF9RwkHAJw"],
-            ["Angel Of Death", "Slayer", "https://www.youtube.com/watch?v=K6_zsJ8KPP0"]
-        ]
-        high = [
-            ["Three Little Birds", "Bob Marley", "https://www.youtube.com/watch?v=LanCLS_hIo4"] , 
-            ["Party in My Tummy", "Yo Gabba Gabba!", "https://www.youtube.com/watch?v=6Os-CACRwM8"]
-        ]
-        
-        #  Occasions
-        netflix = [
-            ["Can't Get Enough Of Your Love Baby", "Barry White", "https://www.youtube.com/watch?v=x0I6mhZ5wMw"],
-            ["My Cherie Amour", "Stevie Wonder", "https://www.youtube.com/watch?v=NW0YcO5P3OM"]
-        ]
-        dance = [
-            ["It's Tricky", "Run-DMC", "https://www.youtube.com/watch?v=l-O5IHVhWj0"],
-            ["Boogie Shoes", "K.C. and Sunshine Band", "https://www.youtube.com/watch?v=6m47EQtAMzI"]
-        ]
-        board_game = [
-            ["Concerning Hobbits", "Howard Shore", "https://www.youtube.com/watch?v=0gLd7rpBJlY"],
-            ["Carmina Burana", "Carl Orff", "https://www.youtube.com/watch?v=GXFSK0ogeg4"]
-        ]
-        cosplay = [
-            ["Sailor Moon Theme", "Nicole and Brynne Price", "https://www.youtube.com/watch?v=5txHGxJRwtQ"],
-            ["Pokémon Theme", "Jason Paige", "https://www.youtube.com/watch?v=rg6CiPI6h2g"]
-        ]
-        fancy_dinner = [
-            ["Impromptu in G flat major D.899, Op. 90 - III. Andante mosso", "Franz Schubert", "https://www.youtube.com/watch?v=Nt33K-HsOHA"],
-            ["Piano Concerto No. 21 in C major, K. 467", "Wolfgang Amadeus Mozart", "https://www.youtube.com/watch?v=CVKpvD3X6EM"]
-        ]
-        hangin_garret = [
-            ["Southern Nights", "Glen Campbell", "https://www.youtube.com/watch?v=7wOUFo4Lwf8"],
-            ["I Just Want To Dance With You", "George Strait", "https://www.youtube.com/watch?v=HxxhNAyj3QQ"]
-        ]
-
-        # create an array with each category for Mood & Occasion
-        @mood_cat = [
-            on_top, 
-            blue, 
-            in_love, 
-            sleep, 
-            rage, 
-            high
-        ]
-        @occasion_cat = [
-            netflix, 
-            dance, 
-            board_game, 
-            cosplay, 
-            fancy_dinner, 
-            hangin_garret
-        ]
-        @list_choice = [@mood_cat, @occasion_cat]
-    end
-    # greets user in terminal and asks for name
-    def greeting
-        puts "Welcome to Ben & Mike's Song Suggestor!".colorize(:light_magenta)
-        puts "What can we call you by?".colorize(:light_cyan)
-        # user_name = user input
-        @user_name = gets.chomp.colorize(:light_white)
+    if @recommender.ai_available?
+      puts "  ✨ AI-powered recommendations enabled".colorize(:light_green)
+    else
+      puts "  📀 Running in curated mode (set ANTHROPIC_API_KEY for AI recommendations)".colorize(:yellow)
     end
 
-    def choose
-        # until loops until @choice1 = 1 or 2
-        # inside the loops it asks the user to choose 1 or 2
-        puts "Hello #{@user_name}! Would you like to select a song for a Mood or an Occasion? "
-        puts "\n"
-        until [1, 2].include? @choice1
-            puts("  1. " + " Mood".colorize(:light_red))
-            puts("  2." + " Occasion".colorize(:light_yellow))
-            puts "\nInput the number of your choice."
-            @choice1 = gets.to_i
+    puts "\nWhat can we call you? ".colorize(:light_cyan)
+    @user_name = gets&.chomp&.strip
+    @user_name = nil if @user_name&.empty?
+  end
 
-            # If the user has input something other than 1 or 2 it will print this error statement
-            if ![1, 2].include? @choice1
-                puts "Sorry, I couldn't read that input, please enter the number of your choice."
-                puts "\n"
-            end
-        end
+  def choose_category_type
+    name = @user_name ? "#{@user_name}!" : "there!"
+    puts "\nHello #{name} Would you like a song for a:".colorize(:light_white)
+
+    choice = prompt_choice([
+      "  1.  Mood   ".colorize(:light_red),
+      "  2.  Occasion   ".colorize(:light_yellow)
+    ])
+
+    choice == 1 ? :mood : :occasion
+  end
+
+  def choose_category(type)
+    if type == :mood
+      puts "\nHow are you feeling?".colorize(:light_white)
+      items = MOODS
+      color = :light_red
+    else
+      puts "\nWhat's the occasion?".colorize(:light_white)
+      items = OCCASIONS
+      color = :light_yellow
     end
 
-    def choose_mood
-        # until @choice2 = 1 to length of moods(6), keep looping
-        # Inside the loops it keeps asking the user to select from a numbered list
-        puts "Are you feeling:"
-        puts "\n"
-        until (1..@moods.length).include? @choice2
-            @moods.each do |item| puts("  " + item.colorize(:light_red)) end
-            puts "\nInput the number of your choice."
-            @choice2 = gets.to_i
+    numbered = items.each_with_index.map { |name, i| "  #{i + 1}.  #{name}  ".colorize(color) }
+    index = prompt_choice(numbered) - 1
+    items[index]
+  end
 
-            # if choice2 != 1 to length of moods(6) print err msg
-            if !(1..@moods.length).include? @choice2
-                puts "Sorry, I couldn't read that input, please enter the number of your choice."
-                puts "\n"
-            end
-        end
+  def suggest_song(type, category_name)
+    puts "\n  🎵 Finding the perfect song...".colorize(:light_cyan) if @recommender.ai_available?
+
+    song = @recommender.recommend(
+      category_type: type,
+      category_name: category_name,
+      user_name: @user_name
+    )
+
+    if song
+      display_song(song)
+    else
+      puts "\n  Sorry, couldn't find a song for that selection.".colorize(:light_red)
+    end
+  end
+
+  def ask_for_another
+    puts "\n  Would you like another suggestion?".colorize(:light_white)
+    choice = prompt_choice([
+      "  1.  Yes, please!   ".colorize(:light_green),
+      "  2.  No thanks, I'm done   ".colorize(:light_red)
+    ])
+
+    if choice == 1
+      @running = true
+    else
+      @running = false
+      puts "\nThanks for using Ben & Mike's Song Suggestor! Enjoy the music! 🎶\n".colorize(:light_magenta)
+    end
+  end
+
+  private
+
+  def display_song(song)
+    puts "\n" + "─" * 42
+    puts "  🎵  #{song[:title]}".colorize(:light_white)
+    puts "  👤  #{song[:artist]}".colorize(:light_white)
+    puts "  🔗  #{song[:url]}".colorize(:light_cyan) unless song[:url].to_s.empty?
+    puts "  💡  #{song[:reason]}".colorize(:light_yellow) if song[:reason]
+    puts "─" * 42
+  end
+
+  def prompt_choice(options)
+    valid_range = (1..options.length)
+    choice = nil
+
+    until valid_range.cover?(choice)
+      puts "\n"
+      options.each { |opt| puts opt }
+      print "\n  Enter a number (#{valid_range.min}-#{valid_range.max}): "
+      choice = gets&.to_i
+
+      unless valid_range.cover?(choice)
+        puts "  Invalid choice. Please enter a number between #{valid_range.min} and #{valid_range.max}.".colorize(:light_red)
+      end
     end
 
-    # until @choice2 = 1 to length of occasions(6), keep looping
-    # Inside the loops it keeps asking the user to select from a numbered list
-    def choose_occ
-        puts "What's the occasion?"
-        puts "\n"
-        until (1..@occasions.length).include? @choice2
-            @occasions.each do |item| puts("  " + item.colorize(:light_yellow)) end
-            puts "\nInput the number of your choice:"
-            @choice2 = gets.to_i
-
-            # if choice2 != 1 to length of moods(6) print err msg
-            if !(1..@occasions.length).include? @choice2
-                puts "Sorry, I couldn't read that input, please enter the number of your choice."
-                puts "\n"
-            end
-        end
-    end
-
-    def suggest_song
-        # receive mood or occasion choice, -1 to make it an arr index
-        @choice1 -= 1
-        # receive mood/occ categories choice, -1 to make it an arr index
-        @choice2 -= 1
-        # category variable = mood/occasion arr
-        category = @list_choice[@choice1]
-        # songs variable = moods/occasions arrays
-        songs = category[@choice2]
-        # song variable looks inside selected mood_cat or occasion_cat and picks a song
-        song = songs[(rand() * songs.length).to_i]
-        puts "\nBen & Mike suggest: #{song[0].colorize(:light_white)} by #{song[1].colorize(:light_white)}."
-        puts "You can listen to it here: #{song[2].colorize(:light_white)}"
-    end
-
-    def start_again?
-        puts "\nWould you like us to suggest another song?"
-        #until choice3 is = 1 or 2 ask for input
-        until [1, 2].include? @choice3
-            puts("\n  1. " + "Yes".colorize(:light_green))
-            puts("  2. " + "No".colorize(:light_red))
-            puts "\nInput 1 for Yes or 2 to exit."
-            @choice3 = gets.to_i
-            if @choice3 == 1
-                @jukebox_running = true
-            elsif @choice3 == 2
-                @jukebox_running = false
-            else 
-                puts "Sorry, I couldn't read that input, please enter the number of your choice."
-                puts "\n"   
-            end
-            #have to set choice1 and choice2 values to nil because it was predefined
-            @choice1 = nil
-            @choice2 = nil
-        end
-        #have to set choice3 to nil because it was predefined, so we can get a new input when we loop
-        @choice3 = nil
-    end
+    choice
+  end
 end
-

--- a/src/data/songs.json
+++ b/src/data/songs.json
@@ -1,0 +1,78 @@
+{
+  "moods": {
+    "On top of the world": [
+      { "title": "Happy", "artist": "Pharrell Williams", "url": "https://www.youtube.com/watch?v=ZbZSe6N_BXs" },
+      { "title": "Hawaiian Roller Coaster Ride", "artist": "Mark Keali'i Ho'omalu", "url": "https://www.youtube.com/watch?v=KaLFZj3wPsc" },
+      { "title": "Walking on Sunshine", "artist": "Katrina and the Waves", "url": "https://www.youtube.com/watch?v=iPUmE-tne5U" },
+      { "title": "Good as Hell", "artist": "Lizzo", "url": "https://www.youtube.com/watch?v=SmbmeOgWsqE" }
+    ],
+    "Blue": [
+      { "title": "Blue (Da Ba Dee)", "artist": "Eiffel 65", "url": "https://www.youtube.com/watch?v=68ugkg9RePc" },
+      { "title": "Born To Die", "artist": "Lana Del Rey", "url": "https://www.youtube.com/watch?v=ORnYNaTZGUU" },
+      { "title": "The Night We Met", "artist": "Lord Huron", "url": "https://www.youtube.com/watch?v=KtlgYxa6BMU" },
+      { "title": "Skinny Love", "artist": "Bon Iver", "url": "https://www.youtube.com/watch?v=sldCiNG15jI" }
+    ],
+    "In love": [
+      { "title": "You Are The Sunshine Of My Life", "artist": "Stevie Wonder", "url": "https://www.youtube.com/watch?v=3wZ_b_uUAdQ" },
+      { "title": "Just The Way You Are", "artist": "Bruno Mars", "url": "https://www.youtube.com/watch?v=LjhCEhWiKXk" },
+      { "title": "Make You Feel My Love", "artist": "Adele", "url": "https://www.youtube.com/watch?v=0put0_a--Ng" },
+      { "title": "All of Me", "artist": "John Legend", "url": "https://www.youtube.com/watch?v=450p7goxZqg" }
+    ],
+    "Sleep deprived": [
+      { "title": "A Whole New World", "artist": "John McClung", "url": "https://www.youtube.com/watch?v=-GN997853gc" },
+      { "title": "Pua Lilelehua", "artist": "Keola Beamer", "url": "https://www.youtube.com/watch?v=s0WyqmvAg7o" },
+      { "title": "Weightless", "artist": "Marconi Union", "url": "https://www.youtube.com/watch?v=UfcAVejslrU" },
+      { "title": "Clair de Lune", "artist": "Claude Debussy", "url": "https://www.youtube.com/watch?v=CvFH_6DNRCY" }
+    ],
+    "Rage": [
+      { "title": "Kamikaze", "artist": "Eminem", "url": "https://www.youtube.com/watch?v=FhF9RwkHAJw" },
+      { "title": "Angel Of Death", "artist": "Slayer", "url": "https://www.youtube.com/watch?v=K6_zsJ8KPP0" },
+      { "title": "Break Stuff", "artist": "Limp Bizkit", "url": "https://www.youtube.com/watch?v=ZpUYjpKg9KY" },
+      { "title": "Killing in the Name", "artist": "Rage Against the Machine", "url": "https://www.youtube.com/watch?v=bWXazVhlyxQ" }
+    ],
+    "A little high": [
+      { "title": "Three Little Birds", "artist": "Bob Marley", "url": "https://www.youtube.com/watch?v=LanCLS_hIo4" },
+      { "title": "Party in My Tummy", "artist": "Yo Gabba Gabba!", "url": "https://www.youtube.com/watch?v=6Os-CACRwM8" },
+      { "title": "In the Air Tonight", "artist": "Phil Collins", "url": "https://www.youtube.com/watch?v=YkADj0TPrJA" },
+      { "title": "Comfortably Numb", "artist": "Pink Floyd", "url": "https://www.youtube.com/watch?v=_FrOQC-zEog" }
+    ]
+  },
+  "occasions": {
+    "Netflix & Chill": [
+      { "title": "Can't Get Enough Of Your Love Baby", "artist": "Barry White", "url": "https://www.youtube.com/watch?v=x0I6mhZ5wMw" },
+      { "title": "My Cherie Amour", "artist": "Stevie Wonder", "url": "https://www.youtube.com/watch?v=NW0YcO5P3OM" },
+      { "title": "Let's Get It On", "artist": "Marvin Gaye", "url": "https://www.youtube.com/watch?v=rBrdqM_X2EM" },
+      { "title": "Slow Hands", "artist": "Niall Horan", "url": "https://www.youtube.com/watch?v=mMnAPjOcJXM" }
+    ],
+    "Dance Battle": [
+      { "title": "It's Tricky", "artist": "Run-DMC", "url": "https://www.youtube.com/watch?v=l-O5IHVhWj0" },
+      { "title": "Boogie Shoes", "artist": "K.C. and Sunshine Band", "url": "https://www.youtube.com/watch?v=6m47EQtAMzI" },
+      { "title": "Get Low", "artist": "Lil Jon & The East Side Boyz", "url": "https://www.youtube.com/watch?v=GNHkGHAkhek" },
+      { "title": "Uptown Funk", "artist": "Mark Ronson ft. Bruno Mars", "url": "https://www.youtube.com/watch?v=OPf0YbXqDm0" }
+    ],
+    "Fantasy Board Game Night": [
+      { "title": "Concerning Hobbits", "artist": "Howard Shore", "url": "https://www.youtube.com/watch?v=0gLd7rpBJlY" },
+      { "title": "Carmina Burana", "artist": "Carl Orff", "url": "https://www.youtube.com/watch?v=GXFSK0ogeg4" },
+      { "title": "Dragonborn (Skyrim Theme)", "artist": "Jeremy Soule", "url": "https://www.youtube.com/watch?v=4z9TdDCWN7g" },
+      { "title": "Geralt of Rivia", "artist": "The Witcher 3 OST", "url": "https://www.youtube.com/watch?v=E0DKbLzHNx8" }
+    ],
+    "Cosplay Party": [
+      { "title": "Sailor Moon Theme", "artist": "Nicole and Brynne Price", "url": "https://www.youtube.com/watch?v=5txHGxJRwtQ" },
+      { "title": "Pokémon Theme", "artist": "Jason Paige", "url": "https://www.youtube.com/watch?v=rg6CiPI6h2g" },
+      { "title": "We Are Number One", "artist": "LazyTown", "url": "https://www.youtube.com/watch?v=hy3ElWuOQEY" },
+      { "title": "Gurren Lagann Theme", "artist": "Shoko Nakagawa", "url": "https://www.youtube.com/watch?v=Jf7-MBSmLv0" }
+    ],
+    "Fancy Dinner Party": [
+      { "title": "Impromptu in G flat major", "artist": "Franz Schubert", "url": "https://www.youtube.com/watch?v=Nt33K-HsOHA" },
+      { "title": "Piano Concerto No. 21 in C major", "artist": "Wolfgang Amadeus Mozart", "url": "https://www.youtube.com/watch?v=CVKpvD3X6EM" },
+      { "title": "La Vie en Rose", "artist": "Édith Piaf", "url": "https://www.youtube.com/watch?v=U9nPTZOHDo4" },
+      { "title": "Fly Me to the Moon", "artist": "Frank Sinatra", "url": "https://www.youtube.com/watch?v=ZEcqHA7dbwM" }
+    ],
+    "Hangin' Out With Garret": [
+      { "title": "Southern Nights", "artist": "Glen Campbell", "url": "https://www.youtube.com/watch?v=7wOUFo4Lwf8" },
+      { "title": "I Just Want To Dance With You", "artist": "George Strait", "url": "https://www.youtube.com/watch?v=HxxhNAyj3QQ" },
+      { "title": "Friends in Low Places", "artist": "Garth Brooks", "url": "https://www.youtube.com/watch?v=4Bnm7gsqFgI" },
+      { "title": "Take Me Home, Country Roads", "artist": "John Denver", "url": "https://www.youtube.com/watch?v=1vrEljMfXYo" }
+    ]
+  }
+}

--- a/src/index.rb
+++ b/src/index.rb
@@ -1,29 +1,14 @@
-require "colorize"
-require_relative "Jukebox"
-# instantiate class
-jukebox = Jukebox.new
-jukebox.jukebox_running
-while jukebox.jukebox_running
-    # run greeting method
-    jukebox.greeting
-    # run choose method which selects mood or occasion
-    jukebox.choose
-    # tells us if prev choice was mood or occasion
-    choice1 = jukebox.choice1
-    # if mood, runs choose_mood method
-    if choice1 == 1
-        jukebox.choose_mood
-        # method choice2 returns mood chosen
-        jukebox.choice2
-    # if occasion, runs choose_occ method
-    else choice1 == 2
-        jukebox.choose_occ
-        # method choice2 returns occasion chosen
-        jukebox.choice2
-    end
-    # runs suggest_song method which looks at chosen mood/occasion and outputs song info
-    jukebox.suggest_song
-    # runs start_again? method 
-    jukebox.start_again?
-end
+# frozen_string_literal: true
 
+require "dotenv/load"
+require_relative "Jukebox"
+
+jukebox = Jukebox.new
+jukebox.greeting
+
+while jukebox.running?
+  type = jukebox.choose_category_type
+  category = jukebox.choose_category(type)
+  jukebox.suggest_song(type, category)
+  jukebox.ask_for_another
+end

--- a/src/music_recommender.rb
+++ b/src/music_recommender.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "anthropic"
+require "json"
+
+# Uses Claude AI to generate personalized music recommendations.
+# Falls back to the curated songs.json database when the API is unavailable.
+class MusicRecommender
+  FALLBACK_DATA_PATH = File.join(__dir__, "data", "songs.json")
+
+  def initialize
+    @client = build_client
+    @fallback_data = load_fallback_data
+  end
+
+  # Returns a song hash with :title, :artist, :url, :reason keys.
+  # category_type is :mood or :occasion, category_name is the selected label.
+  def recommend(category_type:, category_name:, user_name: nil)
+    if @client
+      recommend_with_ai(category_type: category_type, category_name: category_name, user_name: user_name)
+    else
+      recommend_from_fallback(category_type: category_type, category_name: category_name)
+    end
+  end
+
+  def ai_available?
+    !@client.nil?
+  end
+
+  private
+
+  def build_client
+    api_key = ENV["ANTHROPIC_API_KEY"]
+    return nil if api_key.nil? || api_key.strip.empty? || api_key == "your_api_key_here"
+
+    Anthropic::Client.new(api_key: api_key)
+  rescue StandardError
+    nil
+  end
+
+  def load_fallback_data
+    JSON.parse(File.read(FALLBACK_DATA_PATH))
+  rescue StandardError
+    { "moods" => {}, "occasions" => {} }
+  end
+
+  def recommend_with_ai(category_type:, category_name:, user_name:)
+    greeting = user_name ? "The user's name is #{user_name}. " : ""
+    type_label = category_type == :mood ? "mood" : "occasion"
+
+    prompt = <<~PROMPT
+      #{greeting}Recommend ONE song that perfectly fits the #{type_label}: "#{category_name}".
+
+      Respond with ONLY valid JSON in this exact format, no other text:
+      {
+        "title": "Song Title",
+        "artist": "Artist Name",
+        "url": "https://www.youtube.com/watch?v=VIDEOID",
+        "reason": "One sentence explaining why this song fits the #{type_label}"
+      }
+
+      Rules:
+      - Pick a real, well-known song
+      - Use a real YouTube URL (youtube.com/watch?v=...)
+      - Keep reason to one sentence
+      - Do not include markdown formatting
+    PROMPT
+
+    response = @client.messages.create(
+      model: :"claude-opus-4-6",
+      max_tokens: 256,
+      messages: [{ role: "user", content: prompt }]
+    )
+
+    text = response.content.find { |b| b.type == :text }&.text || ""
+    parse_ai_response(text)
+  rescue StandardError
+    recommend_from_fallback(category_type: category_type, category_name: category_name)
+  end
+
+  def parse_ai_response(text)
+    json_text = text.gsub(/```(?:json)?/, "").strip
+    data = JSON.parse(json_text)
+    {
+      title: data["title"] || "Unknown",
+      artist: data["artist"] || "Unknown",
+      url: data["url"] || "",
+      reason: data["reason"]
+    }
+  rescue JSON::ParserError
+    nil
+  end
+
+  def recommend_from_fallback(category_type:, category_name:)
+    collection = category_type == :mood ? @fallback_data["moods"] : @fallback_data["occasions"]
+    songs = collection[category_name] || []
+    return nil if songs.empty?
+
+    song = songs.sample
+    {
+      title: song["title"],
+      artist: song["artist"],
+      url: song["url"],
+      reason: nil
+    }
+  end
+end


### PR DESCRIPTION
- Add Claude API integration (anthropic gem) for AI-powered music recommendations
  that adapt to mood/occasion context, with personality-aware suggestions
- Add MusicRecommender class that falls back gracefully to curated JSON database
  when no API key is configured
- Externalize song data to src/data/songs.json with expanded catalog (4 songs/category)
- Modernize Jukebox.rb: frozen constants, keyword args, cleaner control flow,
  remove hard-coded data, use Array#sample instead of manual random indexing
- Add dotenv for ANTHROPIC_API_KEY management (.env.example included)
- Add RSpec test suite (14 tests covering recommender, fallback data integrity,
  and Jukebox constants)
- Add Gemfile with bundler dependency management

https://claude.ai/code/session_01LWpno7NZmiMkhMKJBKMxvX